### PR TITLE
`__new()__`-based factory initalization

### DIFF
--- a/gmm.py
+++ b/gmm.py
@@ -57,45 +57,45 @@ class GMMEstimatorScipy(GMMEstimator):
         """
         Quadratic form to be minimized.
         """
-        moments = self.moment_cond(self.z, self.y, self.x, beta)
+        moments = self.moment_cond(self.z_, self.y_, self.x_, beta)
         if self.weighting_matrix == "optimal":
-            self.W = self.optimal_weighting_matrix(moments)
+            self.W_ = self.optimal_weighting_matrix(moments)
         else:
-            self.W = np.eye(moments.shape[1])
+            self.W_ = np.eye(moments.shape[1])
         mavg = moments.mean(axis=0)
-        return mavg.T @ self.W @ mavg
+        return mavg.T @ self.W_ @ mavg
 
     def optimal_weighting_matrix(self, moments):
         """
         Optimal Weight matrix
         """
-        return np.linalg.inv((1 / self.n) * (moments.T @ moments))
+        return np.linalg.inv((1 / self.n_) * (moments.T @ moments))
 
     def fit(self, z, y, x, verbose=False, fit_method=None):
         if fit_method is None:
             fit_method = "L-BFGS-B"
-        self.z, self.y, self.x = z, y, x
-        self.n, self.k = x.shape
+        self.z_, self.y_, self.x_ = z, y, x
+        self.n_, self.k_ = x.shape
         # minimize the objective function
         result = scipy.optimize.minimize(
             self.gmm_objective,
-            x0=np.random.rand(self.k),
+            x0=np.random.rand(self.k_),
             method=fit_method,
             options={"disp": verbose},
         )
-        self.theta = result.x
+        self.theta_ = result.x
         # Standard error calculation
         try:
-            self.Gamma = self.jacobian_moment_cond()
-            self.vθ = np.linalg.inv(self.Gamma.T @ self.W @ self.Gamma)
-            self.std_errors = np.sqrt(self.n * np.diag(self.vθ))
+            self.Gamma_ = self.jacobian_moment_cond()
+            self.vθ_ = np.linalg.inv(self.Gamma_.T @ self.W_ @ self.Gamma_)
+            self.std_errors_ = np.sqrt(self.n_ * np.diag(self.vθ_))
         except:
-            self.std_errors = None
+            self.std_errors_ = None
 
     def jacobian_moment_cond(self):
         """Jacobian of the moment condition"""
-        self.jac_est = -self.z.T @ self.x
-        return self.jac_est
+        self.jac_est_ = -self.z_.T @ self.x_
+        return self.jac_est_
 
 
 # %%
@@ -110,61 +110,61 @@ class GMMEstimatorTorch(GMMEstimator):
         """
         Quadratic form to be minimized.
         """
-        moments = self.moment_cond(self.z, self.y, self.x, beta)
+        moments = self.moment_cond(self.z_, self.y_, self.x_, beta)
         if self.weighting_matrix == "optimal":
-            self.W = self.optimal_weighting_matrix(moments)
+            self.W_ = self.optimal_weighting_matrix(moments)
         else:
-            self.W = torch.eye(moments.shape[1])
+            self.W_ = torch.eye(moments.shape[1])
         mavg = moments.mean(axis=0)
         return torch.matmul(
             mavg.unsqueeze(-1).T,
-            torch.matmul(self.W, mavg),
+            torch.matmul(self.W_, mavg),
         )
 
     def optimal_weighting_matrix(self, moments):
         """
         Optimal Weight matrix
         """
-        return torch.inverse((1 / self.n) * torch.matmul(moments.T, moments))
+        return torch.inverse((1 / self.n_) * torch.matmul(moments.T, moments))
 
     def fit(self, z, y, x, verbose=False, fit_method=None):
         if fit_method is None:
             fit_method = "l-bfgs"
         # minimize blackbox using pytorch
-        self.z, self.y, self.x = (
+        self.z_, self.y_, self.x_ = (
             torch.tensor(z, dtype=torch.float64),
             torch.tensor(y, dtype=torch.float64),
             torch.tensor(x, dtype=torch.float64),
         )
-        self.n, self.k = x.shape
+        self.n_, self.k_ = x.shape
         beta_init = torch.tensor(
-            np.random.rand(self.k), dtype=torch.float64, requires_grad=True
+            np.random.rand(self.k_), dtype=torch.float64, requires_grad=True
         )
         result = torchmin.minimize(
             self.gmm_objective, beta_init, method=fit_method, tol=1e-5, disp=verbose
         )
-        self.W = self.W.detach().numpy()
+        self.W_ = self.W_.detach().numpy()
         # solution
-        self.theta = result.x
+        self.theta_ = result.x
 
         # Standard error calculation
         try:
-            self.Gamma = self.jacobian_moment_cond()
-            self.vθ = np.linalg.inv(self.Gamma.T @ self.W @ self.Gamma)
-            self.std_errors = np.sqrt(self.n * np.diag(self.vθ))
+            self.Gamma_ = self.jacobian_moment_cond()
+            self.vθ_ = np.linalg.inv(self.Gamma_.T @ self.W_ @ self.Gamma_)
+            self.std_errors_ = np.sqrt(self.n_ * np.diag(self.vθ_))
         except:
-            self.std_errors = None
+            self.std_errors_ = None
 
     def jacobian_moment_cond(self):
         """
         Jacobian of the moment condition
         """
         # forward mode automatic differentiation wrt 3rd arg (parameter vector)
-        self.jac = torch.func.jacfwd(self.moment_cond, argnums=3)
-        self.jac_est = (
-            self.jac(self.z, self.y, self.x, self.theta).sum(axis=0).detach().numpy()
+        self.jac_ = torch.func.jacfwd(self.moment_cond, argnums=3)
+        self.jac_est_ = (
+            self.jac_(self.z_, self.y_, self.x_, self.theta_).sum(axis=0).detach().numpy()
         )
-        return self.jac_est
+        return self.jac_est_
 
 
 _BACKENDS = {

--- a/gmm.py
+++ b/gmm.py
@@ -102,6 +102,11 @@ class GMMEstimatorScipy(GMMEstimator):
         self.jac_est_ = -self.z_.T @ self.x_
         return self.jac_est_
 
+    @staticmethod
+    def iv_moment(z, y, x, beta):
+        """Linear IV moment condition in numpy"""
+        return z * (y - x @ beta)[:, np.newaxis]
+
 
 # %%
 class GMMEstimatorTorch(GMMEstimator):
@@ -171,21 +176,14 @@ class GMMEstimatorTorch(GMMEstimator):
         )
         return self.jac_est_
 
+    @staticmethod
+    def iv_moment(z, y, x, beta):
+        """Linear IV moment condition in torch"""
+        return z * (y - x @ beta).unsqueeze(-1)
+
 
 _BACKENDS = {
     "scipy": GMMEstimatorScipy,
     "torch": GMMEstimatorTorch,
 }
 
-# %% moment conditions to pass to GMM class
-def iv_moment_pytorch(z, y, x, beta):
-    """Linear IV moment condition in torch"""
-    return z * (y - x @ beta).unsqueeze(-1)
-
-
-def iv_moment_numpy(z, y, x, beta):
-    """Linear IV moment condition in numpy"""
-    return z * (y - x @ beta)[:, np.newaxis]
-
-
-# %%

--- a/gmm.py
+++ b/gmm.py
@@ -41,8 +41,13 @@ class GMMEstimator:
         raise NotImplementedError
 
     def summary(self):
+        if not hasattr(self, "theta_") and not hasattr(self, "std_errors_"):
+            raise AttributeError(
+                "Attributes `theta_` and `std_errors_` do not exist. "
+                "Make sure you called `fit()` before `summary()`."
+            )
         return pd.DataFrame(
-            {"coef": self.estimator.theta, "std err": self.estimator.std_errors}
+            {"coef": self.theta_, "std err": self.std_errors_}
         )
 
 

--- a/gmm.py
+++ b/gmm.py
@@ -10,17 +10,17 @@ import torchmin
 
 class GMMEstimator:
     """Class to create GMM estimator using scipy or torch backend."""
-    def __new__(cls, moment_cond, weighting_matrix="optimal", opt="scipy"):
-        opt = opt.lower()
-        estimator = _BACKENDS.get(opt)
+    def __new__(cls, moment_cond, weighting_matrix="optimal", backend="scipy"):
+        backend = backend.lower()
+        estimator = _BACKENDS.get(backend)
         if estimator is None:
             raise ValueError(
-                f"Backend {opt} is not supported. "
+                f"Backend {backend} is not supported. "
                 f"Supported backend are: {list(_BACKENDS.keys())}"
             )
         return super(GMMEstimator, cls).__new__(estimator)
 
-    def __init__(self, moment_cond, weighting_matrix="optimal", opt="scipy"):
+    def __init__(self, moment_cond, weighting_matrix="optimal", backend="scipy"):
         self.moment_cond = moment_cond
         self.weighting_matrix = weighting_matrix
 
@@ -49,9 +49,9 @@ class GMMEstimator:
 class GMMEstimatorScipy(GMMEstimator):
     """Class to create GMM estimator using scipy"""
 
-    def __init__(self, moment_cond, weighting_matrix="optimal", opt="scipy"):
+    def __init__(self, moment_cond, weighting_matrix="optimal", backend="scipy"):
         """Generalized Method of Moments Estimator with Scipy"""
-        super().__init__(moment_cond, weighting_matrix, opt)
+        super().__init__(moment_cond, weighting_matrix, backend)
 
     def gmm_objective(self, beta):
         """
@@ -102,9 +102,9 @@ class GMMEstimatorScipy(GMMEstimator):
 class GMMEstimatorTorch(GMMEstimator):
     """Class to create GMM estimator using torch"""
 
-    def __init__(self, moment_cond, weighting_matrix="optimal", opt="torch"):
+    def __init__(self, moment_cond, weighting_matrix="optimal", backend="torch"):
         """Generalized Method of Moments Estimator in PyTorch"""
-        super().__init__(moment_cond, weighting_matrix, opt)
+        super().__init__(moment_cond, weighting_matrix, backend)
 
     def gmm_objective(self, beta):
         """

--- a/test_gmm.py
+++ b/test_gmm.py
@@ -6,16 +6,16 @@ from gmm import GMMEstimator, GMMEstimatorTorch, GMMEstimatorScipy
 class TestGMMEstimator(unittest.TestCase):
     def test_backend_initialization(self):
         with self.subTest("Scipy backend"):
-            estimator = GMMEstimator(None, opt="scipy")
+            estimator = GMMEstimator(None, backend="scipy")
             self.assertIsInstance(estimator, GMMEstimatorScipy)
 
         with self.subTest("Torch backend"):
-            estimator = GMMEstimator(None, opt="torch")
+            estimator = GMMEstimator(None, backend="torch")
             self.assertIsInstance(estimator, GMMEstimatorTorch)
 
         with self.subTest("Nonexistent backend"):
             with self.assertRaises(ValueError):
-                GMMEstimator(None, opt="NONEXISTENT")
+                GMMEstimator(None, backend="NONEXISTENT")
 
 
 class TestGMMEstimatorScipy(unittest.TestCase):

--- a/test_gmm.py
+++ b/test_gmm.py
@@ -1,0 +1,33 @@
+import unittest
+
+from gmm import GMMEstimator, GMMEstimatorTorch, GMMEstimatorScipy
+
+
+class TestGMMEstimator(unittest.TestCase):
+    def test_backend_initialization(self):
+        with self.subTest("Scipy backend"):
+            estimator = GMMEstimator(None, opt="scipy")
+            self.assertIsInstance(estimator, GMMEstimatorScipy)
+
+        with self.subTest("Torch backend"):
+            estimator = GMMEstimator(None, opt="torch")
+            self.assertIsInstance(estimator, GMMEstimatorTorch)
+
+        with self.subTest("Nonexistent backend"):
+            with self.assertRaises(ValueError):
+                GMMEstimator(None, opt="NONEXISTENT")
+
+
+class TestGMMEstimatorScipy(unittest.TestCase):
+    # TODO
+    pass
+
+
+class TestGMMEstimatorTorch(unittest.TestCase):
+    # TODO
+    pass
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR follows the chat on Bluesky and does several code-tidying things (but nothing too comprehensive).
1. It makes `GMMEstimator` an abstract class for the scipy/torch implementations to inherent from.
2. It applies `__new()__` as a factory to return the correct scipy/torch implementation based on `backend` argument [[1](https://stackoverflow.com/a/5953974/7708413), [2](https://stackoverflow.com/a/545786/7708413)]
    1. (yes, I also renamed `opt` to `backend`).
    2. I added tests to test that.
3. I added trailing underscores to post-init attributes. That follows [good practices from scikit-learn](https://scikit-learn.org/stable/developers/develop.html#estimated-attributes) (though I would reconsider saving all that data as attributes instead of passing them around to the relevant methods, I personally prefer stateless objects as much as possible). 
4. I also moved the `iv_moment` external functions into the relevant scipy/torch classes. Not sure that's correct, but I haven't seen them used anywhere.

Feel free to revert any single commit that you don't like (they should be relatively independent). 